### PR TITLE
fix: mapping - use nmap/xmap instead map

### DIFF
--- a/plugin/metarepeat.vim
+++ b/plugin/metarepeat.vim
@@ -104,6 +104,7 @@ endfunction
 " ---
 
 if get(g:, 'meterepeat#default_mapping', 1)
-  map g. <Plug>(metarepeat)
+  nmap g. <Plug>(metarepeat)
+  xmap g. <Plug>(metarepeat)
   nmap go <Plug>(metarepeat-preset-occurence)
 endif


### PR DESCRIPTION
Replace `map` to `nmap` / `xmap` .

`map` to map for normal(n)/visual(x)/select(s)/operator(o).
Do not work select and operator mapping.
